### PR TITLE
Add cross-site request note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ The landing URI is where the middleware redirects the user when the
 authentication process is complete. This could just be back to the
 index page, or it could be to the user's account page.
 
+Please note, you should enable cookies to be sent with cross-site requests,
+in order to make the callback request handling work correctly, eg:
+```clojure
+(wrap-defaults (-> site-defaults (assoc-in [:session :cookie-attrs :same-site] :lax)))
+```
+
 ## Workflow diagram
 
 The following image is a workflow diagram that describes the OAuth2


### PR DESCRIPTION
During the callback, the session was empty, so the state check failed. 
Enabling cookies to be sent with cross-site requests seems to fix the 
issue. (I had hard time to figure it out, so it might be useful for others)
