### PR TITLE
Covers edge case of parametrised authorize-uri

### DIFF
--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -17,7 +17,8 @@
   (str/join " " (map name (:scopes profile))))
 
 (defn- authorize-uri [profile request state]
-  (str (:authorize-uri profile) "?"
+  (str (:authorize-uri profile) 
+       (if (.contains ^String (:authorize-uri profile) "?") "&" "?")
        (codec/form-encode {:response_type "code"
                            :client_id     (:client-id profile)
                            :redirect_uri  (redirect-uri profile request)

--- a/test/ring/middleware/oauth2_test.clj
+++ b/test/ring/middleware/oauth2_test.clj
@@ -39,6 +39,15 @@
     (is (= {::oauth2/state (params "state")}
            (:session response)))))
 
+(deftest test-location-uri-with-query
+  (let [profile  (assoc test-profile 
+                        :authorize-uri 
+                        "https://example.com/oauth2/authorize?business_partner_id=XXXX")
+        handler   (wrap-oauth2 token-handler {:test profile})
+        response  (handler (mock/request :get "/oauth2/test"))
+        location  (get-in response [:headers "Location"])]
+    (is (.startsWith ^String location "https://example.com/oauth2/authorize?business_partner_id=XXXX&"))))
+
 (def token-response
   {:status  200
    :headers {"Content-Type" "application/json"}


### PR DESCRIPTION
Sometimes `authorization-uri` may contain additional parameters, like:

    https://identity.company.com/oauth2/authorize?business_partner_id=XXXX

In this case appending ? would break the URL, but checking should help.