### PR TITLE
Creds in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ The landing URI is where the middleware redirects the user when the
 authentication process is complete. This could just be back to the
 index page, or it could be to the user's account page.
 
+* `:creds-in-header?`
+
+This is an optional parameter, which defaults to false. If set to true, it includes the client-id and secret as header
+`Authorization: Basic base64(id:secret)` as recommended by [spec](https://tools.ietf.org/html/rfc6749#section-2.3.1)
+
 Please note, you should enable cookies to be sent with cross-site requests,
 in order to make the callback request handling work correctly, eg:
 ```clojure

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-oauth2 "0.1.0"
+(defproject ring-oauth2 "0.2.0"
   :description "OAuth 2.0 client middleware for Ring"
   :url "https://github.com/weavejester/ring-oauth2"
   :license {:name "The MIT License"

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -49,7 +49,7 @@
                        :as     :json
                        :form-params {:grant_type    "authorization_code"
                                      :code          (get-in request [:query-params "code"])
-                                     :redirect_uri  (req/request-url request)}}
+                                     :redirect_uri  (redirect-uri profile request)}}
                  (true? creds-in-header?) (assoc :basic-auth [client-id client-secret])
                  (false? creds-in-header?) (assoc-in [:form-params :client_id] client-id)
                  (false? creds-in-header?) (assoc-in [:form-params :client_secret] client-secret)))))

--- a/test/ring/middleware/oauth2_test.clj
+++ b/test/ring/middleware/oauth2_test.clj
@@ -90,3 +90,93 @@
     (is (= {:status 200, :headers {}, :body tokens}
            (test-handler (-> (mock/request :get "/")
                              (assoc :session {::oauth2/access-tokens tokens})))))))
+
+
+
+
+; Tests with new parameter
+
+(def test-profile-2
+  {:authorize-uri    "https://example.com/oauth2/authorize"
+   :access-token-uri "https://example.com/oauth2/access-token"
+   :redirect-uri     "/oauth2/test/callback"
+   :launch-uri       "/oauth2/test"
+   :landing-uri      "/"
+   :scopes           [:user :project]
+   :client-id        "abcdef"
+   :client-secret    "01234567890abcdef"
+   :creds-in-header? true})
+
+(defn token-handler-2 [{:keys [oauth2/access-tokens]}]
+  {:status 200, :headers {}, :body access-tokens})
+
+(def test-handler-2
+  (wrap-oauth2 token-handler-2 {:test test-profile-2}))
+
+(deftest test-launch-uri-2
+  (let [response  (test-handler-2 (mock/request :get "/oauth2/test"))
+        location  (get-in response [:headers "Location"])
+        [_ query] (str/split location #"\?" 2)
+        params    (codec/form-decode query)]
+    (is (= 302 (:status response)))
+    (is (.startsWith ^String location "https://example.com/oauth2/authorize?"))
+    (is (= {"response_type" "code"
+            "client_id"     "abcdef"
+            "redirect_uri"  "http://localhost/oauth2/test/callback"
+            "scope"         "user project"}
+           (dissoc params "state")))
+    (is (re-matches #"[A-Za-z0-9_-]{12}" (params "state")))
+    (is (= {::oauth2/state (params "state")}
+           (:session response)))))
+
+(def token-response-2
+  {:status  200
+   :headers {"Content-Type" "application/json"}
+   :body    "{\"access_token\":\"defdef\",\"expires_in\":3600}"})
+
+(defn approx-eq [a b]
+  (time/within?
+   (time/interval (time/minus a (time/seconds 1)) (time/plus a (time/seconds 1)))
+   b))
+
+(deftest test-redirect-uri-2
+  (fake/with-fake-routes
+    {"https://example.com/oauth2/access-token" (constantly token-response-2)}
+
+    (testing "valid state"
+      (let [request  (-> (mock/request :get "/oauth2/test/callback")
+                         (assoc :session {::oauth2/state "xyzxyz"})
+                         (assoc :query-params {"code" "abcabc", "state" "xyzxyz"}))
+            response (test-handler-2 request)
+            expires  (-> 3600 time/seconds time/from-now)]
+        (is (= 302 (:status response)))
+        (is (= "/" (get-in response [:headers "Location"])))
+        (is (map? (-> response :session ::oauth2/access-tokens)))
+        (is (= "defdef" (-> response :session ::oauth2/access-tokens :test :token)))
+        (is (approx-eq (-> 3600 time/seconds time/from-now)
+                       (-> response :session ::oauth2/access-tokens :test :expires)))))
+
+    (testing "invalid state"
+      (let [request  (-> (mock/request :get "/oauth2/test/callback")
+                         (assoc :session {::oauth2/state "xyzxyz"})
+                         (assoc :query-params {"code" "abcabc", "state" "xyzxya"}))
+            response (test-handler-2 request)]
+        (is (= {:status 400, :headers {}, :body "State mismatch"}
+               response))))
+
+    (testing "custom error"
+      (let [error    {:status 400, :headers {}, :body "Error!"}
+            profile  (assoc test-profile-2 :state-mismatch-handler (constantly error))
+            handler  (wrap-oauth2 token-handler-2 {:test profile})
+            request  (-> (mock/request :get "/oauth2/test/callback")
+                         (assoc :session {::oauth2/state "xyzxyz"})
+                         (assoc :query-params {"code" "abcabc", "state" "xyzxya"}))
+            response (handler request)]
+        (is (= {:status 400, :headers {}, :body "Error!"}
+               response))))))
+
+(deftest test-access-tokens-key-2
+  (let [tokens {:test {:token "defdef", :expires 3600}}]
+    (is (= {:status 200, :headers {}, :body tokens}
+           (test-handler-2 (-> (mock/request :get "/")
+                             (assoc :session {::oauth2/access-tokens tokens})))))))


### PR DESCRIPTION
changes include
- support the recommended way of passing creds as specified in the [spec](https://tools.ietf.org/html/rfc6749#section-2.3.1). Newer authorizations servers expect creds in header not in form body
- ensure redirect_uri is consistent throughout the process, as stricter authorizations servers expect it to be exactly the same
- Added tests to make sure new parameter `creds-in-header?` is optional and does not break old tests