### PR TITLE
Optionally include refresh_token and id_token into session

### DIFF
--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -37,10 +37,12 @@
   (= (get-in request [:session ::state])
      (get-in request [:query-params "state"])))
 
-(defn- format-access-token [{{:keys [access_token expires_in]} :body :as r}]
+(defn- format-access-token
+  [{{:keys [access_token expires_in refresh_token id_token]} :body :as r}]
   (-> {:token access_token}
-      (cond-> expires_in (assoc :expires (-> expires_in time/seconds
-                                                        time/from-now)))))
+      (cond-> expires_in (assoc :expires (-> expires_in time/seconds time/from-now))
+              refresh_token (assoc :refresh-token refresh_token)
+              id_token (assoc :id-token id_token))))
 
 (defn- request-params [profile request]
   {:grant_type    "authorization_code"


### PR DESCRIPTION
I am using this against an authorization server which supports openid connect and refresh tokens
This conditionally adds them to the session if in response
As per [specification](http://openid.net/specs/openid-connect-core-1_0.html#TokenResponse) 