### PR TITLE
Support absolute redirect uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ The launch URI kicks off the authorization process. Your log-in link
 should point to this address, and it should be unique per profile.
 
 The redirect URI provides the internal callback. It can be any
-relative URI as long as it is unique.
+relative URI as long as it is unique. It can also be an absolute URI like
+`https://loadbalanced-url.com/oauth2/github/callback`
 
 The landing URI is where the middleware redirects the user when the
 authentication process is complete. This could just be back to the

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -17,7 +17,7 @@
   (str/join " " (map name (:scopes profile))))
 
 (defn- authorize-uri [profile request state]
-  (str (:authorize-uri profile) 
+  (str (:authorize-uri profile)
        (if (.contains ^String (:authorize-uri profile) "?") "&" "?")
        (codec/form-encode {:response_type "code"
                            :client_id     (:client-id profile)
@@ -87,10 +87,13 @@
     (assoc request :oauth2/access-tokens tokens)
     request))
 
+(defn- parse-redirect-url [{:keys [redirect-uri]}]
+  (.getPath (java.net.URI. redirect-uri)))
+
 (defn wrap-oauth2 [handler profiles]
   (let [profiles  (for [[k v] profiles] (assoc v :id k))
         launches  (into {} (map (juxt :launch-uri identity)) profiles)
-        redirects (into {} (map (juxt :redirect-uri identity)) profiles)]
+        redirects (into {} (map (juxt parse-redirect-url identity)) profiles)]
     (fn [{:keys [uri] :as request}]
       (if-let [profile (launches uri)]
         ((make-launch-handler profile) request)


### PR DESCRIPTION
This gives the ability to specify the redirect uri as an absolute path, this is useful in the scenario of 
https://loadbalancer.com -> http://backend.com ... in this case the current version would create a redirect-uri of http://loadbalancer.com/callback instead of https://loadbalancer.com/callback (which is the uri registered at the authorization server)
With these changes
- if you specify `:redirect-uri     "/oauth2/test/callback"` continues working as expected
- if you specify `:redirect-uri  "https://example.com/oauth2/test/callback"` uses the complete url as the redirect, but also correctly creates a handler for `/oauth2/test/callback` 