### PR TITLE
Minor typo in GitHub example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ to authorize against a third-party service.
 Here's an example that provides authentication with GitHub:
 
 ```clojure
-(require '[ring.middleware.oauth2 :refer [wrap-oauth2])
+(require '[ring.middleware.oauth2 :refer [wrap-oauth2]])
 
 (def handler
   (wrap-oauth2


### PR DESCRIPTION
Fixing an unclosed vector in the example code.