### PR TITLE
Extra docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ in order to make the callback request handling work correctly, eg:
 (wrap-defaults (-> site-defaults (assoc-in [:session :cookie-attrs :same-site] :lax)))
 ```
 
+Also, you must make sure that `ring.middleware.params/wrap-params` is
+enabled and runs before this middleware, as this library depends on the
+`:query-params` key to be present in the request.
+
 Once the middleware is set up, navigating to the `:launch-uri` will
 kick off the authorization process. If it succeeds, then the user will
 be directed to the `:landing-uri`. Once the user is authenticated, a


### PR DESCRIPTION
I found out the hard way that when you don't have `wrap-params` enabled, the `:code` parameter will be set to `nil` in the `get-access-token` function call (ie. the POST request), yielding a 401 on the other side. The `state-matches?` function gives a false positive, since it'll return `(= nil nil)`, yielding true. Nice little clusterf***, hehe.

I am using compojure.api, which is why I never (had the need to(?)) set this default middleware.

It took me a bit of digging to figure this out, overwriting your functions through the REPL (yay for the REPL), and then I saw the `:code` param was not set.

It learned me using the repl a bit better though, so at least I came out of this with more experience ;-)