### PR TITLE
improvement: no longer crash when expires_in param is a string

### DIFF
--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -38,10 +38,18 @@
   (= (get-in request [:session ::state])
      (get-in request [:query-params "state"])))
 
+(defn- coerce-to-int [n]
+  (if (string? n)
+    (Integer/parseInt n)
+    n))
+
 (defn- format-access-token
   [{{:keys [access_token expires_in refresh_token id_token]} :body :as r}]
   (-> {:token access_token}
-      (cond-> expires_in (assoc :expires (-> expires_in time/seconds time/from-now))
+      (cond-> expires_in (assoc :expires (-> expires_in
+                                             coerce-to-int
+                                             time/seconds
+                                             time/from-now))
               refresh_token (assoc :refresh-token refresh_token)
               id_token (assoc :id-token id_token))))
 


### PR DESCRIPTION
Occasionally there are services sending back the `expires_in` parameter in string
format, ie. "600". This improvement coerces this value to an integer rather
than crashing with a ClassCastException.