### PR TITLE
Add extra data to access-tokens map

### DIFF
--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -44,8 +44,9 @@
     n))
 
 (defn- format-access-token
-  [{{:keys [access_token expires_in refresh_token id_token]} :body :as r}]
-  (-> {:token access_token}
+  [{{:keys [access_token expires_in refresh_token id_token] :as body} :body :as _r}]
+  (-> {:token access_token
+       :extra-data (dissoc body :access_token :expires_in :refresh_token :id_token)}
       (cond-> expires_in (assoc :expires (-> expires_in
                                              coerce-to-int
                                              time/seconds


### PR DESCRIPTION
Some OAuth flows (e.g. Slack) will return extra data together with
auth-token which need to be stored/processed.