### PR TITLE
Store time in session as java.util.Date rather than joda-time

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [cheshire "5.8.0"]
                  [clj-http "3.7.0"]
-                 [clj-time "0.14.0"]
+                 [clj-time "0.15.1"]
                  [ring/ring-core "1.6.3"]]
   :profiles
   {:dev {:dependencies [[clj-http-fake "1.0.3"]

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -2,7 +2,6 @@
   (:require [clj-http.client :as http]
             [clj-time.coerce :as coerce]
             [clj-time.core :as time]
-            [clj-time.coerce :as time-coerce]
             [clojure.string :as str]
             [crypto.random :as random]
             [ring.util.codec :as codec]


### PR DESCRIPTION
The newer version of clj-time supports tagged literals for clj-time/date-time. Fixes #27