### PR TITLE
Pass params submitted to launch-uri to authorization-uri

### DIFF
--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -3,6 +3,7 @@
             [clj-time.core :as time]
             [clojure.string :as str]
             [crypto.random :as random]
+            [ring.middleware.params :refer [wrap-params]]
             [ring.util.codec :as codec]
             [ring.util.request :as req]
             [ring.util.response :as resp]))
@@ -19,20 +20,23 @@
 (defn- authorize-uri [profile request state]
   (str (:authorize-uri profile)
        (if (.contains ^String (:authorize-uri profile) "?") "&" "?")
-       (codec/form-encode {:response_type "code"
-                           :client_id     (:client-id profile)
-                           :redirect_uri  (redirect-uri profile request)
-                           :scope         (scopes profile)
-                           :state         state})))
+       (codec/form-encode 
+         (merge (:query-params request)
+                {:response_type "code"
+                 :client_id     (:client-id profile)
+                 :redirect_uri  (redirect-uri profile request)
+                 :scope         (scopes profile)
+                 :state         state }))))
 
 (defn- random-state []
   (-> (random/base64 9) (str/replace "+" "-") (str/replace "/" "_")))
 
 (defn- make-launch-handler [profile]
-  (fn [{:keys [session] :or {session {}} :as request}]
-    (let [state (random-state)]
-      (-> (resp/redirect (authorize-uri profile request state))
-          (assoc :session (assoc session ::state state))))))
+  (wrap-params
+    (fn [{:keys [session] :or {session {}} :as request}]
+      (let [state (random-state)]
+        (-> (resp/redirect (authorize-uri profile request state))
+            (assoc :session (assoc session ::state state)))))))
 
 (defn- state-matches? [request]
   (= (get-in request [:session ::state])

--- a/test/ring/middleware/oauth2_test.clj
+++ b/test/ring/middleware/oauth2_test.clj
@@ -56,6 +56,15 @@
         location  (get-in response [:headers "Location"])]
     (is (.startsWith ^String location "https://example.com/oauth2/authorize?business_partner_id=XXXX&"))))
 
+(deftest test-location-uri-with-dynamic-query
+  (let [profile   test-profile
+        handler   (wrap-oauth2 token-handler {:test profile})
+        response  (handler (-> (mock/request :post "/oauth2/test?hd=tenant.com" {:hd "tenant.com"})
+                               (mock/content-type "application/x-www-form-urlencoded")))
+        location  (get-in response [:headers "Location"])]
+     (print ^String location)
+    (is (.startsWith ^String location "https://example.com/oauth2/authorize?hd=tenant.com&"))))
+
 (def token-response
   {:status  200
    :headers {"Content-Type" "application/json"}


### PR DESCRIPTION
Some OAuth providers support extra query params that aren't appropriate for hardcoding. One example is Google OAuth, which accepts an `hd` param to the authorization URL that can restrict logins to users with the provided email domain.

This allows a developer to submit a request to the launch-uri with parameters. These parameters will now be passed along to the authorization URI as the user is sent to the OAuth provider to authenticate.

Also adds a test for this functionality.

https://github.com/weavejester/ring-oauth2/issues/41

I'm definitely out of my element here! I ran a linter and it didnt catch anything but I'm not sure I handled indentation correctly. 