### PR TITLE
Add PKCE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ and complete authentication of the user.
 
 [the specification]: https://tools.ietf.org/html/rfc6749#section-2.3.1
 
+### PKCE
+
+Some oauth providers require an additional step called *Proof Key for 
+Code Exchange* ([PKCE][]).  Ring-OAuth2 will include a proof key in the 
+workflow when `:pkce? true`is included in the profile map.
+
+[pkce]: https://www.oauth.com/oauth2-servers/pkce/authorization-request/
+
 ## Workflow diagram
 
 The following image is a workflow diagram that describes the OAuth2

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -50,7 +50,7 @@
 (defn- random-state []
   (base64url (random/base64 9)))
 
-(defn- random-code-verifier []
+(defn random-code-verifier []
   (base64url (random/base64 63)))
 
 (defn- make-launch-handler [{:keys [pkce?] :as profile}]


### PR DESCRIPTION
Thanks for the great library @weavejester .  Twitter requires a small extension to standard oauth called PKCE ([details](https://oauth.net/2/pkce/)).  I suggest adding a `:pkce?` boolean to the config that auto generates the required parameters when true.  Supplied is a minimal working implementation that satisfies twitter.

If you agree with this feature I will add proper random generation and documentation / unit tests.  I wanted to see whether you agree with the feature first.