### PR TITLE
Fix #27 by using java.util.Date for storing expiration time

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,6 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [cheshire "5.10.1"]
                  [clj-http "3.12.3"]
-                 [clj-time "0.15.2"]
                  [ring/ring-core "1.9.4"]]
   :profiles
   {:dev {:dependencies [[clj-http-fake "1.0.3"]


### PR DESCRIPTION
Hopefully we can get this fix merged soonish, this is the 3rd PR regarding this.

The testing code changes are copied from PR #47, I hope @jamiepratt does not mind.

Requires Java 8 due to use of java.time.Instant in code for clarity