### PR TITLE
Refresh expired access tokens

### DIFF
--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -193,7 +193,7 @@
 
 (defn- expired-access-tokens
   [access-tokens]
-  (let [now (new Date)]
+  (let [now (Date.)]
     (for [[profile-key {:keys [expires refresh-token]}] access-tokens
           :when (and expires refresh-token (.before expires now))]
       {:profile-key profile-key :refresh-token refresh-token})))

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -290,12 +290,12 @@
          ((make-launch-handler profile) request)
          (if-let [profile (redirects uri)]
            ((:redirect-handler profile (make-redirect-handler profile)) request)
-           (let [access-tokens (get-in request [:session ::access-tokens])
-                 refreshed-tokens (refresh-all-tokens profiles access-tokens)]
+           (let [access-tokens (->> (get-in request [:session ::access-tokens])
+                                    (refresh-all-tokens profiles))]
              (-> request
-                 (assoc-access-tokens-in-request refreshed-tokens)
+                 (assoc-access-tokens-in-request access-tokens)
                  handler
-                 (assoc-access-tokens-in-response refreshed-tokens))))))
+                 (assoc-access-tokens-in-response access-tokens))))))
       ([{:keys [uri] :as request} respond raise]
        (if-let [profile (launches uri)]
          ((make-launch-handler profile) request respond raise)
@@ -303,12 +303,12 @@
            ((:redirect-handler profile (make-redirect-handler profile))
             request respond raise)
            (let [access-tokens (get-in request [:session ::access-tokens])
-                 respond (fn [refreshed-tokens]
+                 respond (fn [access-tokens]
                            (handler
                             (assoc-access-tokens-in-request
-                             request refreshed-tokens)
+                             request access-tokens)
                             (comp respond
                                   #(assoc-access-tokens-in-response
-                                    % refreshed-tokens))
+                                    % access-tokens))
                             raise))]
              (refresh-all-tokens profiles access-tokens respond))))))))

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -192,7 +192,6 @@
                          raise)))))
 
 (defn- expired-access-tokens
-  "Returns expired profile keys and refresh tokens in `access-tokens`."
   [access-tokens]
   (let [now (new Date)]
     (for [[profile-key {:keys [expires refresh-token]}] access-tokens
@@ -200,8 +199,6 @@
       {:profile-key profile-key :refresh-token refresh-token})))
 
 (defn- update-tokens
-  "If `maybe-grant` is nil, removes `profile-key` from `access-token; otherwise
-  merges `profile-key` with `maybe-grant`."
   [access-tokens [profile-key maybe-grant]]
   (if maybe-grant
     ;; `update ... merge` to properly handle case where authorization server
@@ -233,7 +230,6 @@
   (and token (string? token) (not (str/blank? token))))
 
 (defn- refresh-all-tokens
-  "Refreshes all expired tokens, yielding an updated map of tokens"
   ([profiles access-tokens]
    (let [refresh-results
          (for [{:keys [profile-key refresh-token]} (expired-access-tokens access-tokens)
@@ -272,7 +268,6 @@
     request))
 
 (defn- assoc-access-tokens-in-response
-  "If any tokens are present, adds to them the `:session` key of `response`."
   [response tokens]
   (if tokens
     (assoc-in response [:session ::access-tokens] tokens)
@@ -285,19 +280,6 @@
   (and (some? client-id) (some? client-secret)))
 
 (defn wrap-oauth2
-  "Middleware that handles OAuth2 authentication flows.
-
-   Parameters:
-   * `handler`: The downstream ring handler
-   * `profiles`: A map of profiles
-
-   Each request URI is matched against the profiles to determine the appropriate
-   OAuth2 flow handler. If no match is found, the request is passed to the
-   downstream handler with existing access tokens added to the request under the
-  `:oauth2/access-tokens` key.
-
-  Expired tokens are refreshed using their refresh-token if possible. If refresh
-  fails, the access token is removed."
   [handler profiles]
   {:pre [(every? valid-profile? (vals profiles))]}
   (let [id-profiles  (for [[k v] profiles] (assoc v :id k))

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -296,7 +296,7 @@
 
 (defn wrap-oauth2 [handler profiles]
   {:pre [(every? valid-profile? (vals profiles))]}
-  (let [id-profiles  (for [[k v] profiles] (assoc v :id k))
+  (let [id-profiles (for [[k v] profiles] (assoc v :id k))
         launches  (into {} (map (juxt :launch-uri identity)) id-profiles)
         redirects (into {} (map (juxt parse-redirect-url identity)) id-profiles)
         handler (wrap-refresh-access-tokens handler profiles)]

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -130,15 +130,13 @@
 
 (defn- get-access-token
   ([profile request]
-   (-> (access-token-http-options profile request)
-       http/request
+   (-> (http/request (access-token-http-options profile request))
        (format-access-token)))
   ([profile request respond raise]
-   (http/request
-    (-> (access-token-http-options profile request)
-        (assoc :async? true))
-    (comp respond format-access-token)
-    raise)))
+   (http/request (-> (access-token-http-options profile request)
+                     (assoc :async? true))
+                 (comp respond format-access-token)
+                 raise)))
 
 (defn state-mismatch-handler
   ([_]

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -226,15 +226,12 @@
               :socket-timeout socket-timeout)
        (http/request (comp respond format-access-token) raise))))
 
-(defn- valid-token? [token]
-  (and token (string? token) (not (str/blank? token))))
-
 (defn- refresh-all-tokens
   ([profiles access-tokens]
    (let [refresh-results
          (for [{:keys [profile-key refresh-token]} (expired-access-tokens access-tokens)
                :let [profile (profile-key profiles)]
-               :when (and profile (valid-token? refresh-token))]
+               :when (and profile refresh-token)]
            [profile-key
             (try (refresh-one-token profile refresh-token)
                  (catch clojure.lang.ExceptionInfo _
@@ -253,7 +250,7 @@
        (respond access-tokens)
        (doseq [{:keys [profile-key refresh-token]} expired
                :let [profile (profile-key profiles)]
-               :when (and profile (valid-token? refresh-token))]
+               :when (and profile refresh-token)]
          (refresh-one-token profile refresh-token
                             (fn [refresh-result]
                               (swap! results assoc profile-key refresh-result)

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -210,20 +210,18 @@
 (def refresh-socket-timeout 60000)
 
 (defn- refresh-token-request-options [profile refresh-token]
-  (token-http-options profile {:grant_type "refresh_token"
-                               :refresh_token refresh-token}))
+  (-> (token-http-options profile {:grant_type "refresh_token"
+                                   :refresh_token refresh-token})
+      (assoc :socket-timeout refresh-socket-timeout)))
 
 (defn- refresh-one-token
   ([profile refresh-token]
-   (-> (refresh-token-request-options profile refresh-token)
-       (assoc :socket-timeout refresh-socket-timeout)
-       http/request
+   (-> (http/request (refresh-token-request-options profile refresh-token))
        format-access-token))
   ([profile refresh-token respond raise]
-   (-> (refresh-token-request-options profile refresh-token)
-       (assoc :async? true
-              :socket-timeout refresh-socket-timeout)
-       (http/request (comp respond format-access-token) raise))))
+   (let [opts (-> (refresh-token-request-options profile refresh-token)
+                  (assoc :async? true))]
+     (http/request opts (comp respond format-access-token) raise))))
 
 (defn- refresh-tasks [profiles access-tokens]
   (->> (expired-access-tokens access-tokens)

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -263,10 +263,20 @@
 (defn- nil-session? [response]
   (and (contains? response :session) (nil? (:session response))))
 
-(defn- assoc-access-tokens-in-response [original-tokens updated-tokens response]
-  (if (or (nil-session? response) (= original-tokens updated-tokens))
-    response
-    (assoc-in response [:session ::access-tokens] updated-tokens)))
+(defn- assoc-access-tokens-in-response
+  [request original-tokens updated-tokens response]
+  (cond
+    ;; handler explicitly cleared the session, we simply forward
+    (nil-session? response) response
+    ;; tokens did not update, again forward as-is
+    (= original-tokens updated-tokens) response
+    ;; handler is also changing session; add our refresh to the change
+    (contains? response :session) (assoc-in response [:session ::access-tokens]
+                                            updated-tokens)
+    ;; handler did not change session, update original
+    :else (let [original-session (get request :session)]
+            (assoc response :session
+                   (assoc original-session ::access-tokens updated-tokens)))))
 
 (defn- wrap-refresh-access-tokens [handler profiles]
   (fn ([request]
@@ -274,7 +284,7 @@
              tokens'  (refresh-all-tokens profiles tokens)
              request  (assoc-access-tokens-in-request request tokens')
              response (handler request)]
-         (assoc-access-tokens-in-response tokens tokens' response)))
+         (assoc-access-tokens-in-response request tokens tokens' response)))
     ([request respond raise]
      (let [tokens (get-in request [:session ::access-tokens])]
        (refresh-all-tokens
@@ -282,7 +292,7 @@
         (fn [tokens']
           (let [request (assoc-access-tokens-in-request request tokens')
                 respond #(respond (assoc-access-tokens-in-response
-                                   tokens tokens' %))]
+                                   request tokens tokens' %))]
             (handler request respond raise))))))))
 
 (defn- parse-redirect-url [{:keys [redirect-uri]}]

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -231,9 +231,8 @@
     (if (zero? total)
       (respond {})
       (doseq [[k v] m]
-        (let [respond #(respond-when-done (swap! results assoc k %))
-              raise (fn [_] (respond nil))]
-          (f v respond raise))))))
+        (let [respond #(respond-when-done (swap! results assoc k %))]
+          (f v respond))))))
 
 (defn- refresh-all-tokens
   ([profiles access-tokens]
@@ -245,8 +244,10 @@
         (reduce update-tokens access-tokens)))
   ([profiles access-tokens respond]
    (async-map-values
-    (fn [[profile refresh-token] respond raise]
-      (refresh-one-token profile refresh-token respond raise))
+    (fn [[profile refresh-token] respond]
+      ;; on failure, yield a result of `nil` as refreshed token to signal error
+      (let [raise (fn [_] (respond nil))]
+        (refresh-one-token profile refresh-token respond raise)))
     (fn [refreshed-tokens]
       (respond
        (reduce update-tokens access-tokens refreshed-tokens)))

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -270,23 +270,20 @@
 
 (defn- wrap-refresh-access-tokens [handler profiles]
   (fn ([request]
-       (let [access-tokens (get-in request [:session ::access-tokens])
-             updated-access-tokens (refresh-all-tokens profiles access-tokens)
-             response (handler (assoc-access-tokens-in-request request
-                                                 updated-access-tokens))]
-         (assoc-access-tokens-in-response access-tokens updated-access-tokens
-                                          response)))
+       (let [tokens   (get-in request [:session ::access-tokens])
+             tokens'  (refresh-all-tokens profiles tokens)
+             request  (assoc-access-tokens-in-request request tokens')
+             response (handler request)]
+         (assoc-access-tokens-in-response tokens tokens' response)))
     ([request respond raise]
-     (let [access-tokens (get-in request [:session ::access-tokens])
-           respond
-           (fn [updated-access-tokens]
-             (let [request (assoc-access-tokens-in-request
-                            request updated-access-tokens)
-                   update-session (partial assoc-access-tokens-in-response
-                                           access-tokens updated-access-tokens)
-                   respond (comp respond update-session)]
-               (handler request respond raise)))]
-       (refresh-all-tokens profiles access-tokens respond)))))
+     (let [tokens (get-in request [:session ::access-tokens])]
+       (refresh-all-tokens
+        profiles tokens
+        (fn [tokens']
+          (let [request (assoc-access-tokens-in-request request tokens')
+                respond #(respond (assoc-access-tokens-in-response
+                                   tokens tokens' %))]
+            (handler request respond raise))))))))
 
 (defn- parse-redirect-url [{:keys [redirect-uri]}]
   (.getPath (java.net.URI. redirect-uri)))

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -191,11 +191,11 @@
                            (respond (redirect-response profile session token)))
                          raise)))))
 
-(defn- expired-access-tokens [access-tokens]
-  (let [expired-access-token? (fn [[_ {:keys [expires refresh-token]}]]
-                                (and refresh-token expires
-                                     (.before expires (Date.))))]
-    (->> access-tokens (filter expired-access-token?) (into {}))))
+(defn- expired-access-token? [{:keys [expires refresh-token]}]
+  (and refresh-token expires (.before expires (Date.))))
+
+(defn expired-access-tokens [tokens]
+  (into {} (filter (comp expired-access-token? val)) tokens))
 
 (defn- update-tokens [access-tokens [profile-key maybe-grant]]
   (if maybe-grant

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -227,39 +227,39 @@
               :socket-timeout refresh-socket-timeout)
        (http/request (comp respond format-access-token) raise))))
 
+(defn- refresh-tasks [profiles access-tokens]
+  (->> (expired-access-tokens access-tokens)
+       (keep (fn [[profile-key {:keys [refresh-token]}]]
+               (when (and (get profiles profile-key) refresh-token)
+                 [profile-key [(get profiles profile-key) refresh-token]])))))
+
+(defn- async-map-values [f respond m]
+  (let [total (count m)
+        results (atom {})
+        respond-when-done #(when (= (count %) total) (respond %))]
+    (if (zero? total)
+      (respond {})
+      (doseq [[k v] m
+              :let [respond #(respond-when-done (swap! results assoc k %))
+                    raise (fn [_] (respond nil))]]
+        (f v respond raise)))))
+
 (defn- refresh-all-tokens
   ([profiles access-tokens]
-   (let [refresh-results
-         (for [[profile-key {:keys [refresh-token]}] (expired-access-tokens
-                                                      access-tokens)
-               :let [profile (profile-key profiles)]
-               :when (and profile refresh-token)]
-           [profile-key
-            (try (refresh-one-token profile refresh-token)
-                 (catch clojure.lang.ExceptionInfo _
-                   nil))])]
-     (reduce update-tokens access-tokens refresh-results)))
+   (->> (refresh-tasks profiles access-tokens)
+        (map (fn [[profile-key [profile refresh-token]]]
+               [profile-key
+                (try (refresh-one-token profile refresh-token)
+                     (catch clojure.lang.ExceptionInfo _ nil))]))
+        (reduce update-tokens access-tokens)))
   ([profiles access-tokens respond]
-   ;; strategy: launch all requests concurrently, keeping track of completed
-   ;; requests in `results`. When all requests have finished, respond.
-   (let [expired (expired-access-tokens access-tokens)
-         total (count expired)
-         results (atom {})  ;; map from profile-key to result
-         respond-when-done! #(when (= (count @results) total)
-                               (respond (reduce update-tokens
-                                                access-tokens @results)))]
-     (if (zero? total)
-       (respond access-tokens)
-       (doseq [[profile-key {:keys [refresh-token]}] expired
-               :let [profile (profile-key profiles)]
-               :when (and profile refresh-token)]
-         (refresh-one-token profile refresh-token
-                            (fn [refresh-result]
-                              (swap! results assoc profile-key refresh-result)
-                              (respond-when-done!))
-                            (fn [_]
-                              (swap! results assoc profile-key nil)
-                              (respond-when-done!))))))))
+   (async-map-values
+    (fn [[profile refresh-token] respond raise]
+      (refresh-one-token profile refresh-token respond raise))
+    (fn [refreshed-tokens]
+      (respond
+       (reduce update-tokens access-tokens refreshed-tokens)))
+    (refresh-tasks profiles access-tokens))))
 
 (defn- assoc-access-tokens-in-request [request tokens]
   (if tokens
@@ -304,11 +304,10 @@
             request respond raise)
            (let [access-tokens (get-in request [:session ::access-tokens])
                  respond (fn [access-tokens]
-                           (handler
-                            (assoc-access-tokens-in-request
-                             request access-tokens)
-                            (comp respond
-                                  #(assoc-access-tokens-in-response
-                                    % access-tokens))
-                            raise))]
+                           (let [request (assoc-access-tokens-in-request
+                                          request access-tokens)
+                                 respond (comp respond
+                                               #(assoc-access-tokens-in-response
+                                                 % access-tokens))]
+                             (handler request respond raise)))]
              (refresh-all-tokens profiles access-tokens respond))))))))

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -205,12 +205,9 @@
     (update access-tokens profile-key merge maybe-grant)
     (dissoc access-tokens profile-key)))
 
-(def refresh-socket-timeout 60000)
-
 (defn- refresh-token-http-options [profile refresh-token]
-  (-> (token-http-options profile {:grant_type "refresh_token"
-                                   :refresh_token refresh-token})
-      (assoc :socket-timeout refresh-socket-timeout)))
+  (token-http-options profile {:grant_type "refresh_token"
+                               :refresh_token refresh-token}))
 
 (defn- refresh-one-token
   ([profile refresh-token]

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -260,12 +260,14 @@
     (assoc request :oauth2/access-tokens tokens)
     request))
 
+(defn- nil-session? [response]
+  (and (contains? response :session) (nil? (:session response))))
+
 (defn- assoc-access-tokens-in-response
   [original-tokens updated-tokens response]
-  (if (and (not (contains? response :session))
-           (not= original-tokens updated-tokens))
-    (assoc-in response [:session ::access-tokens] updated-tokens)
-    response))
+  (if (or (nil-session? response) (= original-tokens updated-tokens))
+    response
+    (assoc-in response [:session ::access-tokens] updated-tokens)))
 
 (defn- wrap-refresh-access-tokens [handler profiles]
   (fn ([request]

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -194,10 +194,9 @@
                          raise)))))
 
 (defn- expired-access-tokens [access-tokens]
-  (let [now (Date.)
-        expired-access-token? (fn [[_ {:keys [expires refresh-token]}]]
+  (let [expired-access-token? (fn [[_ {:keys [expires refresh-token]}]]
                                 (and refresh-token expires
-                                     (.before expires now)))]
+                                     (.before expires (Date.))))]
     (->> access-tokens (filter expired-access-token?) (into {}))))
 
 (defn- update-tokens [access-tokens [profile-key maybe-grant]]

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -263,8 +263,7 @@
 (defn- nil-session? [response]
   (and (contains? response :session) (nil? (:session response))))
 
-(defn- assoc-access-tokens-in-response
-  [original-tokens updated-tokens response]
+(defn- assoc-access-tokens-in-response [original-tokens updated-tokens response]
   (if (or (nil-session? response) (= original-tokens updated-tokens))
     response
     (assoc-in response [:session ::access-tokens] updated-tokens)))

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -233,10 +233,10 @@
         respond-when-done #(when (= (count %) total) (respond %))]
     (if (zero? total)
       (respond {})
-      (doseq [[k v] m
-              :let [respond #(respond-when-done (swap! results assoc k %))
-                    raise (fn [_] (respond nil))]]
-        (f v respond raise)))))
+      (doseq [[k v] m]
+        (let [respond #(respond-when-done (swap! results assoc k %))
+              raise (fn [_] (respond nil))]
+          (f v respond raise))))))
 
 (defn- refresh-all-tokens
   ([profiles access-tokens]

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -114,26 +114,29 @@
 
 (defn- access-token-http-options
   [{:keys [access-token-uri client-id client-secret basic-auth?]
-    :or   {basic-auth? false} :as profile}
-   request]
+    :or   {basic-auth? false}}
+   form-params]
   (let [opts {:method      :post
               :url         access-token-uri
               :accept      :json
               :as          :json
-              :form-params (request-params profile request)}]
+              :form-params form-params}]
     (if basic-auth?
       (add-header-credentials opts client-id client-secret)
       (add-form-credentials   opts client-id client-secret))))
 
 (defn- get-access-token
   ([profile request]
-   (-> (http/request (access-token-http-options profile request))
+   (-> (access-token-http-options profile (request-params profile request))
+       http/request
        (format-access-token)))
   ([profile request respond raise]
-   (http/request (-> (access-token-http-options profile request)
-                     (assoc :async? true))
-                 (comp respond format-access-token)
-                 raise)))
+   (http/request
+    (-> (access-token-http-options profile
+                                   (request-params profile request))
+        (assoc :async? true))
+    (comp respond format-access-token)
+    raise)))
 
 (defn state-mismatch-handler
   ([_]
@@ -188,10 +191,91 @@
                            (respond (redirect-response profile session token)))
                          raise)))))
 
-(defn- assoc-access-tokens [request]
-  (if-let [tokens (-> request :session ::access-tokens)]
+(defn- get-expired
+  "Returns expired profile keys and refresh tokens in `access-tokens`."
+  [access-tokens]
+  (let [now (new Date)]
+    (for [[profile-key {:keys [expires refresh-token]}] access-tokens
+          :when (and expires refresh-token (.before expires now))]
+      {:profile-key profile-key :refresh-token refresh-token})))
+
+(defn- update-tokens
+  "If `maybe-grant` is nil, removes `profile-key` from `access-token; otherwise
+  merges `profile-key` with `maybe-grant`."
+  [access-tokens [profile-key maybe-grant]]
+  (if maybe-grant
+    ;; `update ... merge` to properly handle case where authorization server
+    ;; does not update the refresh token after use and we should re-use the
+    ;; existing refresh token
+    (update access-tokens profile-key merge maybe-grant)
+    (dissoc access-tokens profile-key)))
+
+(def socket-timeout 60000)
+
+(defn- refresh-one-token
+  ([profile refresh-token]
+   (-> (access-token-http-options
+        profile
+        {:grant_type "refresh_token" :refresh_token refresh-token})
+       (assoc :socket-timeout socket-timeout)
+       http/request
+       format-access-token))
+  ([profile refresh-token respond raise]
+   (-> (access-token-http-options
+        profile
+        {:grant_type "refresh_token"
+         :refresh_token refresh-token})
+       (assoc :async? true
+              :socket-timeout socket-timeout)
+       (http/request (comp respond format-access-token) raise))))
+
+(defn- valid-token? [token]
+  (and token (string? token) (not (str/blank? token))))
+
+(defn- refresh-all-tokens
+  "Refreshes all expired tokens, yielding an updated map of tokens"
+  ([profiles access-tokens]
+   (let [refresh-results
+         (for [{:keys [profile-key refresh-token]} (get-expired access-tokens)
+               :let [profile (profile-key profiles)]
+               :when (and profile (valid-token? refresh-token))]
+           [profile-key
+            (try (refresh-one-token profile refresh-token)
+                 (catch clojure.lang.ExceptionInfo _
+                   nil))])]
+     (reduce update-tokens access-tokens refresh-results)))
+  ([profiles access-tokens respond]
+   ;; strategy: launch all requests concurrently, keeping track of completed
+   ;; requests in `results`. When all requests have finished, respond.
+   (let [expired (get-expired access-tokens)
+         total (count expired)
+         results (atom {})  ;; map from profile-key to result
+         respond-when-done! #(when (= (count @results) total)
+                               (respond (reduce update-tokens access-tokens @results)))]
+     (if (zero? total)
+       (respond access-tokens)
+       (doseq [{:keys [profile-key refresh-token]} expired
+               :let [profile (profile-key profiles)]
+               :when (and profile (valid-token? refresh-token))]
+         (refresh-one-token profile refresh-token
+                            (fn [refresh-result]
+                              (swap! results assoc profile-key refresh-result)
+                              (respond-when-done!))
+                            (fn [_]
+                              (swap! results assoc profile-key nil)
+                              (respond-when-done!))))))))
+
+(defn- assoc-access-tokens-in-request [request tokens]
+  (if tokens
     (assoc request :oauth2/access-tokens tokens)
     request))
+
+(defn- assoc-access-tokens-in-response
+  "If any tokens are present, adds to them the `:session` key of `response`."
+  [response tokens]
+  (if tokens
+    (assoc-in response [:session ::access-tokens] tokens)
+    response))
 
 (defn- parse-redirect-url [{:keys [redirect-uri]}]
   (.getPath (java.net.URI. redirect-uri)))
@@ -199,22 +283,50 @@
 (defn- valid-profile? [{:keys [client-id client-secret]}]
   (and (some? client-id) (some? client-secret)))
 
-(defn wrap-oauth2 [handler profiles]
+(defn wrap-oauth2
+  "Middleware that handles OAuth2 authentication flows.
+
+   Parameters:
+   * `handler`: The downstream ring handler
+   * `profiles`: A map of profiles
+
+   Each request URI is matched against the profiles to determine the appropriate
+   OAuth2 flow handler. If no match is found, the request is passed to the
+   downstream handler with existing access tokens added to the request under the
+  `:oauth2/access-tokens` key.
+
+  Expired tokens are refreshed using their refresh-token if possible. If refresh
+  fails, the access token is removed."
+  [handler profiles]
   {:pre [(every? valid-profile? (vals profiles))]}
-  (let [profiles  (for [[k v] profiles] (assoc v :id k))
-        launches  (into {} (map (juxt :launch-uri identity)) profiles)
-        redirects (into {} (map (juxt parse-redirect-url identity)) profiles)]
+  (let [id-profiles  (for [[k v] profiles] (assoc v :id k))
+        launches  (into {} (map (juxt :launch-uri identity)) id-profiles)
+        redirects (into {} (map (juxt parse-redirect-url identity)) id-profiles)]
     (fn
       ([{:keys [uri] :as request}]
        (if-let [profile (launches uri)]
          ((make-launch-handler profile) request)
          (if-let [profile (redirects uri)]
            ((:redirect-handler profile (make-redirect-handler profile)) request)
-           (handler (assoc-access-tokens request)))))
+           (let [access-tokens (get-in request [:session ::access-tokens])
+                 refreshed-tokens (refresh-all-tokens profiles access-tokens)]
+             (-> request
+                 (assoc-access-tokens-in-request refreshed-tokens)
+                 handler
+                 (assoc-access-tokens-in-response refreshed-tokens))))))
       ([{:keys [uri] :as request} respond raise]
        (if-let [profile (launches uri)]
          ((make-launch-handler profile) request respond raise)
          (if-let [profile (redirects uri)]
            ((:redirect-handler profile (make-redirect-handler profile))
             request respond raise)
-           (handler (assoc-access-tokens request) respond raise)))))))
+           (let [access-tokens (get-in request [:session ::access-tokens])
+                 respond (fn [refreshed-tokens]
+                           (handler
+                            (assoc-access-tokens-in-request
+                             request refreshed-tokens)
+                            (comp respond
+                                  #(assoc-access-tokens-in-response
+                                    % refreshed-tokens))
+                            raise))]
+             (refresh-all-tokens profiles access-tokens respond))))))))

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -244,7 +244,7 @@
         (map (fn [[profile-key [profile refresh-token]]]
                [profile-key
                 (try (refresh-one-token profile refresh-token)
-                     (catch clojure.lang.ExceptionInfo _ nil))]))
+                     (catch Exception _ nil))]))
         (reduce update-tokens access-tokens)))
   ([profiles access-tokens respond]
    (async-map-values

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -191,7 +191,7 @@
                            (respond (redirect-response profile session token)))
                          raise)))))
 
-(defn- get-expired
+(defn- expired-access-tokens
   "Returns expired profile keys and refresh tokens in `access-tokens`."
   [access-tokens]
   (let [now (new Date)]
@@ -236,7 +236,7 @@
   "Refreshes all expired tokens, yielding an updated map of tokens"
   ([profiles access-tokens]
    (let [refresh-results
-         (for [{:keys [profile-key refresh-token]} (get-expired access-tokens)
+         (for [{:keys [profile-key refresh-token]} (expired-access-tokens access-tokens)
                :let [profile (profile-key profiles)]
                :when (and profile (valid-token? refresh-token))]
            [profile-key
@@ -247,7 +247,7 @@
   ([profiles access-tokens respond]
    ;; strategy: launch all requests concurrently, keeping track of completed
    ;; requests in `results`. When all requests have finished, respond.
-   (let [expired (get-expired access-tokens)
+   (let [expired (expired-access-tokens access-tokens)
          total (count expired)
          results (atom {})  ;; map from profile-key to result
          respond-when-done! #(when (= (count @results) total)

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -263,20 +263,21 @@
 (defn- nil-session? [response]
   (and (contains? response :session) (nil? (:session response))))
 
+(defn- get-current-session [request response]
+  (if (contains? response :session)
+    (:session response)
+    (:session request)))
+
 (defn- assoc-access-tokens-in-response
   [request original-tokens updated-tokens response]
-  (cond
-    ;; handler explicitly cleared the session, we simply forward
-    (nil-session? response) response
-    ;; tokens did not update, again forward as-is
-    (= original-tokens updated-tokens) response
-    ;; handler is also changing session; add our refresh to the change
-    (contains? response :session) (assoc-in response [:session ::access-tokens]
-                                            updated-tokens)
-    ;; handler did not change session, update original
-    :else (let [original-session (get request :session)]
-            (assoc response :session
-                   (assoc original-session ::access-tokens updated-tokens)))))
+  (if (or (nil-session? response)
+          (= original-tokens updated-tokens))
+    ;; either handler explicitly cleared session or no token refresh occurred
+    response
+    ;; otherwise add refreshed tokens to current session
+    (let [session (-> (get-current-session request response)
+                      (assoc ::access-tokens updated-tokens))]
+      (assoc response :session session))))
 
 (defn- wrap-refresh-access-tokens [handler profiles]
   (fn ([request]

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -262,10 +262,32 @@
     (assoc request :oauth2/access-tokens tokens)
     request))
 
-(defn- assoc-access-tokens-in-response [response tokens]
-  (if tokens
-    (assoc-in response [:session ::access-tokens] tokens)
+(defn- assoc-access-tokens-in-response
+  [original-tokens updated-tokens response]
+  (if (and (not (contains? response :session))
+           (not= original-tokens updated-tokens))
+    (assoc-in response [:session ::access-tokens] updated-tokens)
     response))
+
+(defn- wrap-refresh-access-tokens [handler profiles]
+  (fn ([request]
+       (let [access-tokens (get-in request [:session ::access-tokens])
+             updated-access-tokens (refresh-all-tokens profiles access-tokens)
+             response (handler (assoc-access-tokens-in-request request
+                                                 updated-access-tokens))]
+         (assoc-access-tokens-in-response access-tokens updated-access-tokens
+                                          response)))
+    ([request respond raise]
+     (let [access-tokens (get-in request [:session ::access-tokens])
+           respond
+           (fn [updated-access-tokens]
+             (let [request (assoc-access-tokens-in-request
+                            request updated-access-tokens)
+                   update-session (partial assoc-access-tokens-in-response
+                                           access-tokens updated-access-tokens)
+                   respond (comp respond update-session)]
+               (handler request respond raise)))]
+       (refresh-all-tokens profiles access-tokens respond)))))
 
 (defn- parse-redirect-url [{:keys [redirect-uri]}]
   (.getPath (java.net.URI. redirect-uri)))
@@ -277,31 +299,19 @@
   {:pre [(every? valid-profile? (vals profiles))]}
   (let [id-profiles  (for [[k v] profiles] (assoc v :id k))
         launches  (into {} (map (juxt :launch-uri identity)) id-profiles)
-        redirects (into {} (map (juxt parse-redirect-url identity)) id-profiles)]
+        redirects (into {} (map (juxt parse-redirect-url identity)) id-profiles)
+        handler (wrap-refresh-access-tokens handler profiles)]
     (fn
       ([{:keys [uri] :as request}]
        (if-let [profile (launches uri)]
          ((make-launch-handler profile) request)
          (if-let [profile (redirects uri)]
            ((:redirect-handler profile (make-redirect-handler profile)) request)
-           (let [access-tokens (->> (get-in request [:session ::access-tokens])
-                                    (refresh-all-tokens profiles))]
-             (-> request
-                 (assoc-access-tokens-in-request access-tokens)
-                 handler
-                 (assoc-access-tokens-in-response access-tokens))))))
+           (handler request))))
       ([{:keys [uri] :as request} respond raise]
        (if-let [profile (launches uri)]
          ((make-launch-handler profile) request respond raise)
          (if-let [profile (redirects uri)]
            ((:redirect-handler profile (make-redirect-handler profile))
             request respond raise)
-           (let [access-tokens (get-in request [:session ::access-tokens])
-                 respond (fn [access-tokens]
-                           (let [request (assoc-access-tokens-in-request
-                                          request access-tokens)
-                                 respond (comp respond
-                                               #(assoc-access-tokens-in-response
-                                                 % access-tokens))]
-                             (handler request respond raise)))]
-             (refresh-all-tokens profiles access-tokens respond))))))))
+           (handler request respond raise)))))))

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -208,14 +208,14 @@
     (update access-tokens profile-key merge maybe-grant)
     (dissoc access-tokens profile-key)))
 
-(def socket-timeout 60000)
+(def refresh-socket-timeout 60000)
 
 (defn- refresh-one-token
   ([profile refresh-token]
    (-> (access-token-http-options
         profile
         {:grant_type "refresh_token" :refresh_token refresh-token})
-       (assoc :socket-timeout socket-timeout)
+       (assoc :socket-timeout refresh-socket-timeout)
        http/request
        format-access-token))
   ([profile refresh-token respond raise]
@@ -224,7 +224,7 @@
         {:grant_type "refresh_token"
          :refresh_token refresh-token})
        (assoc :async? true
-              :socket-timeout socket-timeout)
+              :socket-timeout refresh-socket-timeout)
        (http/request (comp respond format-access-token) raise))))
 
 (defn- refresh-all-tokens

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -207,17 +207,17 @@
 
 (def refresh-socket-timeout 60000)
 
-(defn- refresh-token-request-options [profile refresh-token]
+(defn- refresh-token-http-options [profile refresh-token]
   (-> (token-http-options profile {:grant_type "refresh_token"
                                    :refresh_token refresh-token})
       (assoc :socket-timeout refresh-socket-timeout)))
 
 (defn- refresh-one-token
   ([profile refresh-token]
-   (-> (http/request (refresh-token-request-options profile refresh-token))
+   (-> (http/request (refresh-token-http-options profile refresh-token))
        format-access-token))
   ([profile refresh-token respond raise]
-   (let [opts (-> (refresh-token-request-options profile refresh-token)
+   (let [opts (-> (refresh-token-http-options profile refresh-token)
                   (assoc :async? true))]
      (http/request opts (comp respond format-access-token) raise))))
 

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -98,7 +98,7 @@
 (defn- get-code-verifier [request]
   (get-in request [:session ::code-verifier]))
 
-(defn- request-params [{:keys [pkce?] :as profile} request]
+(defn- access-token-request-params [{:keys [pkce?] :as profile} request]
   (-> {:grant_type    "authorization_code"
        :code          (get-authorization-code request)
        :redirect_uri  (redirect-uri profile request)}
@@ -112,7 +112,7 @@
                                (merge {:client_id     id
                                        :client_secret secret}))))
 
-(defn- access-token-http-options
+(defn- token-http-options
   [{:keys [access-token-uri client-id client-secret basic-auth?]
     :or   {basic-auth? false}}
    form-params]
@@ -125,15 +125,18 @@
       (add-header-credentials opts client-id client-secret)
       (add-form-credentials   opts client-id client-secret))))
 
+(defn- access-token-http-options
+  [profile request]
+  (token-http-options profile (access-token-request-params profile request)))
+
 (defn- get-access-token
   ([profile request]
-   (-> (access-token-http-options profile (request-params profile request))
+   (-> (access-token-http-options profile request)
        http/request
        (format-access-token)))
   ([profile request respond raise]
    (http/request
-    (-> (access-token-http-options profile
-                                   (request-params profile request))
+    (-> (access-token-http-options profile request)
         (assoc :async? true))
     (comp respond format-access-token)
     raise)))
@@ -210,19 +213,18 @@
 
 (def refresh-socket-timeout 60000)
 
+(defn- refresh-token-request-options [profile refresh-token]
+  (token-http-options profile {:grant_type "refresh_token"
+                               :refresh_token refresh-token}))
+
 (defn- refresh-one-token
   ([profile refresh-token]
-   (-> (access-token-http-options
-        profile
-        {:grant_type "refresh_token" :refresh_token refresh-token})
+   (-> (refresh-token-request-options profile refresh-token)
        (assoc :socket-timeout refresh-socket-timeout)
        http/request
        format-access-token))
   ([profile refresh-token respond raise]
-   (-> (access-token-http-options
-        profile
-        {:grant_type "refresh_token"
-         :refresh_token refresh-token})
+   (-> (refresh-token-request-options profile refresh-token)
        (assoc :async? true
               :socket-timeout refresh-socket-timeout)
        (http/request (comp respond format-access-token) raise))))

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -193,10 +193,11 @@
 
 (defn- expired-access-tokens
   [access-tokens]
-  (let [now (Date.)]
-    (for [[profile-key {:keys [expires refresh-token]}] access-tokens
-          :when (and expires refresh-token (.before expires now))]
-      {:profile-key profile-key :refresh-token refresh-token})))
+  (let [now (Date.)
+        expired-access-token? (fn [[_ {:keys [expires refresh-token]}]]
+                                (and refresh-token expires
+                                     (.before expires now)))]
+    (->> access-tokens (filter expired-access-token?) (into {}))))
 
 (defn- update-tokens
   [access-tokens [profile-key maybe-grant]]
@@ -229,7 +230,8 @@
 (defn- refresh-all-tokens
   ([profiles access-tokens]
    (let [refresh-results
-         (for [{:keys [profile-key refresh-token]} (expired-access-tokens access-tokens)
+         (for [[profile-key {:keys [refresh-token]}] (expired-access-tokens
+                                                      access-tokens)
                :let [profile (profile-key profiles)]
                :when (and profile refresh-token)]
            [profile-key
@@ -248,7 +250,7 @@
                                                 access-tokens @results)))]
      (if (zero? total)
        (respond access-tokens)
-       (doseq [{:keys [profile-key refresh-token]} expired
+       (doseq [[profile-key {:keys [refresh-token]}] expired
                :let [profile (profile-key profiles)]
                :when (and profile refresh-token)]
          (refresh-one-token profile refresh-token

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -125,8 +125,7 @@
       (add-header-credentials opts client-id client-secret)
       (add-form-credentials   opts client-id client-secret))))
 
-(defn- access-token-http-options
-  [profile request]
+(defn- access-token-http-options [profile request]
   (token-http-options profile (access-token-request-params profile request)))
 
 (defn- get-access-token
@@ -194,16 +193,14 @@
                            (respond (redirect-response profile session token)))
                          raise)))))
 
-(defn- expired-access-tokens
-  [access-tokens]
+(defn- expired-access-tokens [access-tokens]
   (let [now (Date.)
         expired-access-token? (fn [[_ {:keys [expires refresh-token]}]]
                                 (and refresh-token expires
                                      (.before expires now)))]
     (->> access-tokens (filter expired-access-token?) (into {}))))
 
-(defn- update-tokens
-  [access-tokens [profile-key maybe-grant]]
+(defn- update-tokens [access-tokens [profile-key maybe-grant]]
   (if maybe-grant
     ;; `update ... merge` to properly handle case where authorization server
     ;; does not update the refresh token after use and we should re-use the
@@ -268,8 +265,7 @@
     (assoc request :oauth2/access-tokens tokens)
     request))
 
-(defn- assoc-access-tokens-in-response
-  [response tokens]
+(defn- assoc-access-tokens-in-response [response tokens]
   (if tokens
     (assoc-in response [:session ::access-tokens] tokens)
     response))
@@ -280,8 +276,7 @@
 (defn- valid-profile? [{:keys [client-id client-secret]}]
   (and (some? client-id) (some? client-secret)))
 
-(defn wrap-oauth2
-  [handler profiles]
+(defn wrap-oauth2 [handler profiles]
   {:pre [(every? valid-profile? (vals profiles))]}
   (let [id-profiles  (for [[k v] profiles] (assoc v :id k))
         launches  (into {} (map (juxt :launch-uri identity)) id-profiles)

--- a/src/ring/middleware/oauth2.clj
+++ b/src/ring/middleware/oauth2.clj
@@ -251,7 +251,8 @@
          total (count expired)
          results (atom {})  ;; map from profile-key to result
          respond-when-done! #(when (= (count @results) total)
-                               (respond (reduce update-tokens access-tokens @results)))]
+                               (respond (reduce update-tokens
+                                                access-tokens @results)))]
      (if (zero? total)
        (respond access-tokens)
        (doseq [{:keys [profile-key refresh-token]} expired

--- a/test/ring/middleware/oauth2_test.clj
+++ b/test/ring/middleware/oauth2_test.clj
@@ -484,4 +484,5 @@
           (handler request respond raise)
           (is (= :empty (deref raise 100 :empty)))
           (let [response (deref respond 100 :empty)]
+            (is (not= response :empty))
             (is (= {:test-1 good-grant} (:body response)))))))))

--- a/test/ring/middleware/oauth2_test.clj
+++ b/test/ring/middleware/oauth2_test.clj
@@ -518,3 +518,43 @@
             (is (= :empty error))
             (is (= 200 (:status response)))
             (is (nil? (:session response)))))))))
+(deftest test-token-refresh-preserves-session-state
+  (fake/with-fake-routes
+    {"https://example.com/oauth2/access-token"
+     (constantly refresh-token-response)}
+
+    (let [now (Instant/now)
+          old-expires (seconds-from-now-to-date now -60)
+          request (-> (mock/request :get "/")
+                      (assoc :session
+                             {:user-id 123  ; extra session state
+                              ::oauth2/access-tokens
+                              {:test {:token "oldtoken"
+                                      :refresh-token "oldrefresh"
+                                      :expires old-expires}}}))]
+
+      (testing "handler sets new session state during refresh"
+        (let [handler (wrap-oauth2
+                       (fn
+                         ([_] {:status 200 :body "ok"
+                               :session {:user-id 123 :cart-items 5}})
+                         ([_ respond _] (respond {:status 200 :body "ok"
+                                                   :session {:user-id 123 :cart-items 5}})))
+                       {:test test-profile})
+              response (handler request)]
+          ;; Handler's session changes preserved
+          (is (= 5 (get-in response [:session :cart-items])))
+          ;; Refreshed token added to handler's session
+          (is (= "newtoken" (get-in response [:session ::oauth2/access-tokens :test :token])))))
+
+      (testing "handler doesn't change session, extra state preserved"
+        (let [handler (wrap-oauth2
+                       (fn
+                         ([_] {:status 200 :body "ok"})
+                         ([_ respond _] (respond {:status 200 :body "ok"})))
+                       {:test test-profile})
+              response (handler request)]
+          ;; Original session's extra state preserved
+          (is (= 123 (get-in response [:session :user-id])))
+          ;; Token refreshed
+          (is (= "newtoken" (get-in response [:session ::oauth2/access-tokens :test :token]))))))))

--- a/test/ring/middleware/oauth2_test.clj
+++ b/test/ring/middleware/oauth2_test.clj
@@ -518,6 +518,7 @@
             (is (= :empty error))
             (is (= 200 (:status response)))
             (is (nil? (:session response)))))))))
+
 (deftest test-token-refresh-preserves-session-state
   (fake/with-fake-routes
     {"https://example.com/oauth2/access-token"

--- a/test/ring/middleware/oauth2_test.clj
+++ b/test/ring/middleware/oauth2_test.clj
@@ -204,10 +204,7 @@
 
 (deftest test-access-tokens-key
   (let [tokens {:test {:token "defdef", :expires 3600}}]
-    (is (= {:status 200,
-            :headers {},
-            :body tokens,
-            :session {::oauth2/access-tokens tokens}}
+    (is (= {:status 200, :headers {}, :body tokens}
            (-> (mock/request :get "/")
                (assoc :session {::oauth2/access-tokens tokens})
                (test-handler))))))
@@ -380,11 +377,10 @@
 
 (deftest test-handler-passthrough
   (let [tokens  {:test "tttkkkk"}
-        session {::oauth2/access-tokens tokens}
         request (-> (mock/request :get "/example")
-                    (assoc :session session))]
+                    (assoc :session {::oauth2/access-tokens tokens}))]
     (testing "sync handler"
-      (is (= {:status 200, :headers {}, :body tokens :session session}
+      (is (= {:status 200, :headers {}, :body tokens}
              (test-handler request))))
 
     (testing "async handler"
@@ -393,7 +389,7 @@
         (test-handler request respond raise)
         (is (= :empty
                (deref raise 100 :empty)))
-        (is (= {:status 200, :headers {}, :body tokens :session session}
+        (is (= {:status 200, :headers {}, :body tokens}
                (deref respond 100 :empty)))))))
 
 (def refresh-token-response
@@ -486,3 +482,39 @@
           (let [response (deref respond 100 :empty)]
             (is (not= response :empty))
             (is (= {:test-1 good-grant} (:body response)))))))))
+
+(deftest test-token-refresh-clear-session
+  (fake/with-fake-routes
+    {"https://example.com/oauth2/access-token"
+     (constantly refresh-token-response)}
+
+    (let [clear-response {:status 200 :headers {} :body nil :session nil}
+          session-clear-handler (fn
+                                  ([_request] clear-response)
+                                  ([_request respond _raise]
+                                   (respond clear-response)))
+          handler (wrap-oauth2 session-clear-handler {:test test-profile})
+          now (Instant/now)
+          old-expires (seconds-from-now-to-date now -60)
+          request (-> (mock/request :get "/")
+                      (assoc :session
+                             {::oauth2/access-tokens
+                              {:test {:token "oldtoken"
+                                      :refresh-token "oldrefresh"
+                                      :expires old-expires}}}))]
+
+      (testing "sync handler"
+        (let [response (handler request)]
+          (is (= 200 (:status response)))
+          (is (nil? (:session response)))))
+
+      (testing "async handler"
+        (let [respond (promise)
+              raise (promise)]
+          (handler request respond raise)
+          (let [response (deref respond 100 :empty)
+                error (deref raise 100 :empty)]
+            (is (not= :empty response))
+            (is (= :empty error))
+            (is (= 200 (:status response)))
+            (is (nil? (:session response)))))))))

--- a/test/ring/middleware/oauth2_test.clj
+++ b/test/ring/middleware/oauth2_test.clj
@@ -109,8 +109,9 @@
         b-ms (.getTime b)]
     (< (- a-ms 1000) b-ms (+ a-ms 1000))))
 
-(defn- seconds-from-now-to-date [secs]
-  (-> (Instant/now) (.plusSeconds secs) (Date/from)))
+(defn- seconds-from-now-to-date
+  ([now secs] (-> now (.plusSeconds secs) (Date/from)))
+  ([secs] (seconds-from-now-to-date (Instant/now) secs)))
 
 (deftest test-redirect-uri
   (fake/with-fake-routes
@@ -203,7 +204,10 @@
 
 (deftest test-access-tokens-key
   (let [tokens {:test {:token "defdef", :expires 3600}}]
-    (is (= {:status 200, :headers {}, :body tokens}
+    (is (= {:status 200,
+            :headers {},
+            :body tokens,
+            :session {::oauth2/access-tokens tokens}}
            (-> (mock/request :get "/")
                (assoc :session {::oauth2/access-tokens tokens})
                (test-handler))))))
@@ -376,10 +380,11 @@
 
 (deftest test-handler-passthrough
   (let [tokens  {:test "tttkkkk"}
+        session {::oauth2/access-tokens tokens}
         request (-> (mock/request :get "/example")
-                    (assoc :session {::oauth2/access-tokens tokens}))]
+                    (assoc :session session))]
     (testing "sync handler"
-      (is (= {:status 200, :headers {}, :body tokens}
+      (is (= {:status 200, :headers {}, :body tokens :session session}
              (test-handler request))))
 
     (testing "async handler"
@@ -388,5 +393,93 @@
         (test-handler request respond raise)
         (is (= :empty
                (deref raise 100 :empty)))
-        (is (= {:status 200, :headers {}, :body tokens}
+        (is (= {:status 200, :headers {}, :body tokens :session session}
                (deref respond 100 :empty)))))))
+
+(def refresh-token-response
+  {:status 200
+   :headers {"Content-Type" "application/json"}
+   :body "{\"access_token\":\"newtoken\",\"expires_in\":3600,
+           \"refresh_token\":\"newrefresh\",\"foo\":\"bar\"}"})
+
+(deftest test-token-refresh-success
+  (fake/with-fake-routes
+    {"https://example.com/oauth2/access-token"
+     (fn [req]
+       (let [params (codec/form-decode (slurp (:body req)))]
+         (is (= "refresh_token" (get params "grant_type")))
+         (is (= "oldrefresh" (get params "refresh_token")))
+         refresh-token-response))}
+
+    (let [now (Instant/now)
+          old-expires  (seconds-from-now-to-date now -60)
+          new-expires  (seconds-from-now-to-date now 3600)
+          new-token    {:token "newtoken"
+                        :refresh-token "newrefresh"
+                        :extra-data {:foo "bar"}}
+          request      (-> (mock/request :get "/")
+                           (assoc :session
+                                  {::oauth2/access-tokens
+                                   {:test {:token "oldtoken"
+                                           :refresh-token "oldrefresh"
+                                           :expires old-expires}}}))]
+      (testing "sync refresh"
+        (let [response (test-handler request)]
+          (is (= 200 (:status response)))
+          ;; then handler has new token
+          (is (= new-token (dissoc (get-in response [:body :test]) :expires)))
+          (is (approx-eq new-expires (get-in response [:body :test :expires])))
+          ;; and the user's session is updated
+          (is (= new-token (dissoc (get-in response [:session ::oauth2/access-tokens :test])
+                                   :expires)))))
+      (testing "async refresh"
+        (let [respond (promise)
+              raise   (promise)]
+          (test-handler request respond raise)
+          (is (= :empty (deref raise 100 :empty)))
+          (let [response (deref respond 100 :empty)]
+            ;; then handler has new token
+            (is (not= response :empty))
+            (is (= new-token (dissoc (get-in response [:body :test]) :expires)))
+            ;; user session is updated
+            (is (= new-token
+                   (dissoc (get-in response [:session ::oauth2/access-tokens
+                                             :test])
+                           :expires)))))))))
+
+(def refresh-token-error-response
+  {:headers {"content-type" "application/json"},
+   :status 400,
+   :body "{\"error\": \"invalid_grant\"}"})
+
+(deftest test-token-refresh-failure
+  (fake/with-fake-routes
+    {"https://example.com/oauth2/access-token"
+     (constantly refresh-token-error-response)}
+
+    ;; setup a session with two grants, where one grant is expired and which
+    ;; will error on refresh
+    (let [profiles      {:test-0 test-profile :test-1 test-profile}
+          handler       (wrap-oauth2 token-handler profiles)
+          good-grant    {:token "good-token"
+                         :refresh-token "refresh-token"
+                         :expires (seconds-from-now-to-date 3600)}
+          expired-grant {:token "expired-token"
+                         :refresh-token "invalid"
+                         :expires (seconds-from-now-to-date -60)}
+          request       (-> (mock/request :get "/")
+                            (assoc :session
+                                   {::oauth2/access-tokens
+                                    {:test-0 expired-grant
+                                     :test-1 good-grant}}))]
+      (testing "sync handler"
+        (let [response (handler request)]
+          (is (= {:test-1 good-grant}
+                 (:body response)))))
+      (testing "async refresh"
+        (let [respond (promise)
+              raise   (promise)]
+          (handler request respond raise)
+          (is (= :empty (deref raise 100 :empty)))
+          (let [response (deref respond 100 :empty)]
+            (is (= {:test-1 good-grant} (:body response)))))))))

--- a/test/ring/middleware/oauth2_test.clj
+++ b/test/ring/middleware/oauth2_test.clj
@@ -539,13 +539,15 @@
                          ([_] {:status 200 :body "ok"
                                :session {:user-id 123 :cart-items 5}})
                          ([_ respond _] (respond {:status 200 :body "ok"
-                                                   :session {:user-id 123 :cart-items 5}})))
+                                                   :session {:user-id 123
+                                                             :cart-items 5}})))
                        {:test test-profile})
               response (handler request)]
           ;; Handler's session changes preserved
           (is (= 5 (get-in response [:session :cart-items])))
           ;; Refreshed token added to handler's session
-          (is (= "newtoken" (get-in response [:session ::oauth2/access-tokens :test :token])))))
+          (is (= "newtoken" (get-in response [:session ::oauth2/access-tokens
+                                              :test :token])))))
 
       (testing "handler doesn't change session, extra state preserved"
         (let [handler (wrap-oauth2
@@ -557,4 +559,5 @@
           ;; Original session's extra state preserved
           (is (= 123 (get-in response [:session :user-id])))
           ;; Token refreshed
-          (is (= "newtoken" (get-in response [:session ::oauth2/access-tokens :test :token]))))))))
+          (is (= "newtoken" (get-in response [:session ::oauth2/access-tokens
+                                              :test :token]))))))))

--- a/test/ring/middleware/oauth2_test.clj
+++ b/test/ring/middleware/oauth2_test.clj
@@ -430,8 +430,10 @@
           (is (= new-token (dissoc (get-in response [:body :test]) :expires)))
           (is (approx-eq new-expires (get-in response [:body :test :expires])))
           ;; and the user's session is updated
-          (is (= new-token (dissoc (get-in response [:session ::oauth2/access-tokens :test])
-                                   :expires)))))
+          (is (= new-token
+                 (dissoc (get-in response
+                                 [:session ::oauth2/access-tokens :test])
+                         :expires)))))
       (testing "async refresh"
         (let [respond (promise)
               raise   (promise)]


### PR DESCRIPTION
Adds an additional flow to the existing middleware to refresh expired
tokens. The implementation handles multiple active grants. Expired
grants that failed to refresh are removed.

The refresh workflow is unconditionally activated. Since a token refresh
may occur for any request, access tokens are now always added to the
response's `:session`. This may break code which previously relied on the
`:session` only being set during the initial grant workflow. I do not
think this can be avoided.

If a refresh occurs, the tokens in `(:session request)` are left as-is,
the updated access tokens are accessibly via the existing
`:oauth2/access-token` key. This allows downstream handlers to observe
that a token refresh occurred.

There is a potential bug, where concurrent requests with expired tokens
may race. For example, consider a page containing a `css` and a `js`
resource. If a user's access token was to expire exactly as the
`index.html` finishes loading, their browser may concurrently fetch both
the `css` and `js` resources, triggering two concurrent token refresh
attempts with the same token, one of which may fail. I do not see a way to
address this without introducing considerable complexity.

I have added a timeout of 60 seconds to the refresh http request, which
means a slow oauth backend will cause users to become logged out. I
think this is more informative for users than hanging forever.

Fixes #40